### PR TITLE
Shorten documentation lines

### DIFF
--- a/R/block_bootstrap.R
+++ b/R/block_bootstrap.R
@@ -1,16 +1,28 @@
 
 #' Wrap data for block sampling
 #'
-#' @param hawkes A `hawkes` object
-#' @param block_length_t A numeric value to set the length of blocks to wrap the process.
+#' @param hawkes A `hawkes` object.
+#' @param block_length_t Length of the temporal block appended to wrap the process.
 #'
 #' @returns A `hawkes` object.
 #' @export
 #'
 #' @examples
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' extend_data_t_only(hawkes, 5)
 #'
 extend_data_t_only <- function(hawkes, block_length_t) {
@@ -50,18 +62,30 @@ extend_data_t_only <- function(hawkes, block_length_t) {
 }
 
 
-#' Resample data with moving blocls
+#' Resample data with moving blocks
 #'
-#' @param hawkes A `hawkes` object
-#' @param num_blocks A numeric value to set the number of blocks to be used for resampling.
+#' @param hawkes A `hawkes` object.
+#' @param num_blocks Number of blocks used for resampling.
 #'
 #' @returns A `hawkes` object.
 #' @export
 #'
 #' @examples
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #'
 #' sample_blocks(hawkes, 25)
 #'
@@ -109,27 +133,47 @@ sample_blocks <- function(hawkes, num_blocks) {
             covariate_columns = covariate_columns)
 }
 
-#' Block Bootstrap for Confidence Intervals of Hawkes MLEs
+#' Block bootstrap for Hawkes MLE confidence intervals
 #'
-#' @param hawkes A `hawkes` object
-#' @param est A `hawkes_est` object containing the parameter estimates of `hawkes`
-#' @param B number of bootstrap iterations
-#' @param num_blocks number of blocs to sample for each bootstap iteration.
-#' @param alpha type-1 error rate for constructing confidence intervals. Defaults to .05 if unused
-#' @param parallel a logical specifying if parallel computation should be used. Parallel computation is implemented with the `furrr` package.
-#' @param max_iters maximum number of iterations to use in maximum likelihood estimation. Defaults to 500 if unused.
-#' @param boundary size of boundary to use for border correction. Defaults to NULL if unused
+#' @param hawkes A `hawkes` object.
+#' @param est A `hawkes_est` object containing parameter estimates for `hawkes`.
+#' @param B Number of bootstrap iterations.
+#' @param num_blocks Number of blocks sampled during each bootstrap iteration.
+#' @param alpha Type I error rate for the confidence intervals. Defaults to 0.05.
+#' @param parallel Logical flag for `furrr` based parallel computation.
+#' @param max_iters Maximum EM iterations per fit. Defaults to 500.
+#' @param boundary Optional boundary width used for edge correction.
 #'
-#' @returns A `hawkes` object.
+#' @returns A tibble of bootstrap estimates.
 #' @export
 #'
 #' @examples
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 #'
-#' block_bootstrap(hawkes, est, B = 2, num_blocks = 25, alpha = .05, parallel = FALSE, boundary = 1)
+#' block_bootstrap(
+#'   hawkes,
+#'   est,
+#'   B = 2,
+#'   num_blocks = 25,
+#'   alpha = 0.05,
+#'   parallel = FALSE,
+#'   boundary = 1
+#' )
 #'
 block_bootstrap <- function(hawkes, est, B, num_blocks, alpha = .05, parallel = FALSE, max_iters = 500, boundary = NULL) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")

--- a/R/cluster_bootstrap.R
+++ b/R/cluster_bootstrap.R
@@ -1,16 +1,28 @@
-#' Resample Data by EM-ALgorithm Clustering
+#' Resample Data by EM Algorithm Clusters
 #'
-#' @param hawkes A `hawkes` object.
-#' @param parent_mat An estimate of the parent matrix produced by `parent_est`.
-#' @param boundary size of boundary to use for border correction. Defaults to NULL if unused.
+#' @param hawkes A `hawkes` object to resample.
+#' @param parent_mat Parent probabilities estimated with `parent_est()`.
+#' @param boundary Optional boundary width used for edge correction.
 #'
-#' @returns A `hawkes` object.
+#' @returns A resampled `hawkes` object.
 #' @export
 #'
 #' @examples
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 #' parent_mat <- parent_est(hawkes, est)
 #' sample_clusters(hawkes, parent_mat, boundary = c(.5,3))
@@ -123,23 +135,35 @@ sample_clusters <- function(hawkes, parent_mat, boundary = NULL) {
 }
 
 
-#' Block Bootstrap for Confidence Intervals of Hawkes MLEs
+#' Block Bootstrap Confidence Intervals for Hawkes MLEs
 #'
-#' @param hawkes A `hawkes` object
-#' @param est A `hawkes_est` object containing the parameter estimates of `hawkes`
-#' @param B number of bootstrap iterations
-#' @param alpha type-1 error rate for constructing confidence intervals. Defaults to .05 if unused
-#' @param parallel a logical specifying if parallel computation should be used. Parallel computation is implemented with the `furrr` package.
-#' @param max_iters maximum number of iterations to use in maximum likelihood estimation. Defaults to 500 if unused.
-#' @param boundary size of boundary to use for border correction. Defaults to NULL if unused
+#' @param hawkes A `hawkes` object.
+#' @param est A `hawkes_est` object with parameter estimates for `hawkes`.
+#' @param B Number of bootstrap iterations.
+#' @param alpha Type I error rate for the interval. Defaults to 0.05.
+#' @param parallel Logical flag for `furrr` based parallel computation.
+#' @param max_iters Maximum EM iterations per fit. Defaults to 500.
+#' @param boundary Optional boundary width used for edge correction.
 #'
-#' @returns A `hawkes` object.
+#' @returns A tibble of bootstrap estimates.
 #' @export
 #'
 #' @examples
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 #'
 #' future::plan(future::multisession, workers = future::availableCores())

--- a/R/hawkes_fit.R
+++ b/R/hawkes_fit.R
@@ -1,9 +1,9 @@
 #' Construct a hawkes_fit object from estimated parameters
 #'
-#' @param hawkes The original hawkes object used to fit the model
-#' @param est A named nested list of estimated parameters, e.g. from `hawkes_mle()`
+#' @param hawkes The original `hawkes` object used to fit the model.
+#' @param est Named nested list of estimated parameters, e.g., from `hawkes_mle()`.
 #'
-#' @return An object of class `hawkes_fit`
+#' @return An object of class `hawkes_fit`.
 #' @export
 new_hawkes_fit <- function(hawkes, est) {
   stopifnot(is.list(est))
@@ -19,21 +19,20 @@ new_hawkes_fit <- function(hawkes, est) {
   )
 }
 
-#' Wald Confidence Intervals for Hawkes Model Parameters
+#' Wald confidence intervals for Hawkes model parameters
 #'
-#' Computes Wald marginal confidence intervals for the parameters of a spatio-temporal Hawkes process
-#' using the estimated covariance matrix from the observed information (negative Hessian).
+#' Computes Wald confidence intervals for Hawkes model parameters using the observed
+#' information (negative Hessian) as a covariance estimate.
 #'
-#' @param object A `hawkes_fit` object
-#' @param parm Parameters to create confidence interval for. (currently not used)
+#' @param object A `hawkes_fit` object.
+#' @param parm Optional parameter subset (currently unused).
 #' @param level Confidence level for the interval. Default is 0.95.
-#' @param ... Further arguments passed to or from other methods.
+#' @param ... Additional arguments passed to other methods.
 #'
-#' @return A data frame with the point estimates and corresponding lower and upper confidence bounds.
-#' The column names match the default format of `confint()`, e.g., `"2.5 %"`, `"97.5 %"`.
+#' @return A tibble with point estimates and lower/upper bounds using `confint()` style
+#'   column names.
 #'
-#' @details The function uses the estimated Hessian of the log-likelihood to compute the covariance matrix.
-#' Fixed parameters (if any) are excluded from the interval computation.
+#' @details Fixed parameters, if any, are excluded when computing intervals.
 #'
 #' @importFrom stats confint
 #'
@@ -42,17 +41,34 @@ new_hawkes_fit <- function(hawkes, est) {
 #'
 #' @examples
 #' set.seed(123)
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' confint(est)
 #'
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 0)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 0
+#' )
 #' est <- hawkes_mle(hawkes, inits = params)
 #' confint(est)
 confint.hawkes_fit <- function(object, parm = NULL, level = 0.95, ...) {

--- a/R/hawkes_object.R
+++ b/R/hawkes_object.R
@@ -3,15 +3,16 @@
 
 #' Constructor for a hawkes object
 #'
-#' @param data A dataframe containing the event locations in the columns x, y, and t. Defaults to NULL if not used.
-#' @param params A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Defaults to NULL if not used.
-#' @param time_window A numeric vector of length 2 specifying the time window.
-#' @param spatial_region An sf object defining the spatial region and covariate regions.
-#' @param covariate_columns A character vector containing the names of covariates columns to be used for the model.
-#' @param spatial_family A spatial triggering kernel function to generate data from. Defaults to NULL if not used.
-#' @param temporal_family A spatial triggering kernel function to generate data from. Defaults to NULL if not used.
+#' @param data Data frame or `sf` object with columns `x`, `y`, and `t`. Defaults to `NULL`.
+#' @param params Optional named list holding background, triggering, spatial, and temporal
+#'   parameters.
+#' @param time_window Numeric vector of length two defining the observation window.
+#' @param spatial_region `sf` object describing the spatial domain and covariate regions.
+#' @param covariate_columns Optional character vector naming background covariates.
+#' @param spatial_family Spatial triggering kernel or list of custom kernel functions.
+#' @param temporal_family Temporal triggering kernel or list of custom kernel functions.
 #'
-#' @returns A hawkes object containing a tibble with the events.
+#' @returns A hawkes object containing a tibble of events.
 #' @export
 #'
 hawkes <- function(data = NULL, params = NULL,
@@ -162,14 +163,15 @@ hawkes <- function(data = NULL, params = NULL,
 #
 
 
-#' Convert an Object to Type Hawkes
+#' Convert an object to a hawkes
 #'
-#' @param data A dataframe containing the event locations in the columns x, y, and t or an sf object containing the event locations in geometry and the event times in a column named t.
-#' @param time_window A numeric vector of length 2 specifying the time window.
-#' @param spatial_region An sf object defining the spatial region and covariate regions.
-#' @param spatial_family A spatial triggering kernel function to generate data from. Defaults to NULL if not used.
-#' @param temporal_family A spatial triggering kernel function to generate data from. Defaults to NULL if not used.
-#' @param covariate_columns A character vector containing the names of covariates columns to be used for the model. Defaults to NULL if not used
+#' @param data Data frame with columns `x`, `y`, and `t`, or an `sf` object with event
+#'   geometry and a `t` column.
+#' @param time_window Numeric vector of length two specifying the observation window.
+#' @param spatial_region `sf` object defining the spatial domain.
+#' @param spatial_family Spatial triggering kernel or list of custom kernel helpers.
+#' @param temporal_family Temporal triggering kernel or list of custom kernel helpers.
+#' @param covariate_columns Optional character vector naming background covariates.
 #'
 #' @returns A hawkes object.
 #' @export
@@ -182,8 +184,14 @@ hawkes <- function(data = NULL, params = NULL,
 #' )
 #'
 #' # Convert to hawkes object
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
-#' hawkes_df <- as_hawkes(df, c(0,50), spatial_region, spatial_family = "Gaussian", temporal_family = "Exponential")
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
+#' hawkes_df <- as_hawkes(
+#'   df,
+#'   c(0, 50),
+#'   spatial_region,
+#'   spatial_family = "Gaussian",
+#'   temporal_family = "Exponential"
+#' )
 #' print(hawkes_df)
 #'
 as_hawkes <- function(data, time_window, spatial_region, spatial_family, temporal_family, covariate_columns = NULL) {

--- a/R/internals.R
+++ b/R/internals.R
@@ -129,13 +129,13 @@
 
 
 
-#' Convert Hawkes Parameter List to Data Frame
+#' Convert Hawkes parameter list to data frame
 #'
-#' Converts a fitted Hawkes parameter list into a tidy data frame with one row per parameter.
+#' Converts fitted Hawkes parameters into a tidy data frame with one row per value.
 #'
-#' @param est A hawkes_fit object of fitted parameter values from a Hawkes model, typically returned by `hawkes_mle()`.
+#' @param est A `hawkes_fit` object or parameter list, typically from `hawkes_mle()`.
 #'
-#' @returns A data frame
+#' @returns A data frame.
 #'
 #' @keywords internal
 .hawkes_mle_to_dataframe <- function(est) {
@@ -160,13 +160,13 @@
 }
 
 
-#' Wrapper for likelihood for numerical optimization
+#' Wrapper for likelihood used in numerical optimization
 #'
-#' @param par_vec a numeric vector of the parameter initial values
-#' @param hawkes a hawkes object
-#' @param param_template a template to reconstruct the parameter object
+#' @param par_vec Numeric vector of parameter values.
+#' @param hawkes A `hawkes` object.
+#' @param param_template Template used to reconstruct the parameter list.
 #'
-#' @returns A numeric of the log_likelihood
+#' @returns The log-likelihood evaluated at `par_vec`.
 #' @export
 #'
 #' @keywords internal

--- a/R/likelihood_functions.R
+++ b/R/likelihood_functions.R
@@ -1,16 +1,22 @@
 #' Compute Conditional Intensity at Each Event
 #'
-#' @param hawkes A hawkes object
-#' @param parameters A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function.
+#' @param hawkes A `hawkes` object.
+#' @param parameters Named list containing background, triggering, spatial, and temporal
+#'   parameters. Values usually represent current estimates.
 #'
-#' @returns A numeric vector
+#' @returns A numeric vector.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' conditional_intensity(hawkes, params)
 conditional_intensity <- function(hawkes, parameters) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
@@ -85,28 +91,46 @@ conditional_intensity <- function(hawkes, parameters) {
 }
 
 
-#' Compute the Conditional Intensity at a Specified Time t
+#' Compute the conditional intensity at a specified time
 #'
 #' @param hawkes A `hawkes` object.
-#' @param parameters A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function.
-#' @param time A time to evaluate the conditional intensity.
-#' @param stepsize A numeric value specifying the size of the grid to evaluate the conditional intensity over.
+#' @param parameters Named list containing background, triggering, spatial, and temporal
+#'   parameters.
+#' @param time Time point where the conditional intensity is evaluated.
+#' @param stepsize Grid cell size used to evaluate the spatial intensity.
 #'
-#' @returns A numeric vector
+#' @returns A numeric vector.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
-#' spatial_conditional_intensity(hawkes, params, 25, .5)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' spatial_conditional_intensity(hawkes, params, 25, 0.5)
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #'
-#' spatial_conditional_intensity(hawkes, params, 25, .5)
+#' spatial_conditional_intensity(hawkes, params, 25, 0.5)
 spatial_conditional_intensity <- function(hawkes, parameters, time, stepsize) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
 
@@ -196,22 +220,28 @@ spatial_conditional_intensity <- function(hawkes, parameters, time, stepsize) {
 }
 
 
-#' Compute the Conditional Intensity at a Specified Location (x,y)
+#' Compute the conditional intensity at a location
 #'
 #' @param hawkes A `hawkes` object.
-#' @param parameters A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function.
-#' @param coordinates A numeric vector of length 2 to specify the location to evaluate the conditional intensity.
-#' @param step A numeric value specifying the size of the grid to evaluate the conditional intensity over.
+#' @param parameters Named list containing background, triggering, spatial, and temporal
+#'   parameters.
+#' @param coordinates Numeric vector of length two giving the evaluation location.
+#' @param step Grid step size used to build the temporal evaluation grid.
 #'
-#' @returns A numeric vector
+#' @returns A numeric vector.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
-#' temporal_conditional_intensity(hawkes, params, c(5,5))
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' temporal_conditional_intensity(hawkes, params, c(5, 5))
 temporal_conditional_intensity <- function(hawkes, parameters, coordinates, step = .1) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
 
@@ -298,19 +328,25 @@ temporal_conditional_intensity <- function(hawkes, parameters, coordinates, step
 }
 
 
-#' Compute Log-Likelihood
+#' Compute log-likelihood
 #'
-#' @param hawkes A hawkes object
-#' @param parameters A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function.
+#' @param hawkes A `hawkes` object.
+#' @param parameters Named list containing background, triggering, spatial, and temporal
+#'   parameters.
 #'
 #' @returns A numeric vector.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.5,spatial = list(mean = 0, sd = 0.5),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, c(0,50), spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.5),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, c(0, 50), spatial_region)
 #' log_likelihood(hawkes, params)
 log_likelihood <- function(hawkes, parameters) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")

--- a/R/maximization_functions.R
+++ b/R/maximization_functions.R
@@ -1,17 +1,18 @@
 
 #' Safe logarithm to avoid log(0)
 #'
-#' Computes the natural logarithm of a numeric vector, replacing values too close to zero with a small positive constant to avoid `-Inf` or `NaN` results.
+#' Safe logarithm with lower bound
 #'
 #' @param x A numeric vector.
 #'
-#' @returns A numeric vector of the same length as `x` with `log(pmax(x, .Machine$double.eps))`.
+#' @returns A numeric vector equal to `log(pmax(x, .Machine$double.eps))`.
 #' @keywords internal
 .safe_log <- function(x) log(pmax(x, .Machine$double.eps))
 
-#' Spatial triggering kernel parameter likelihood
+#' Spatial kernel likelihood contribution
 #'
-#' Computes the (negative) expected complete-data log-likelihood for spatial triggering kernel parameters, assuming separable spatial kernels.
+#' Evaluates the negative expected complete-data log-likelihood for separable spatial
+#' triggering kernels.
 #'
 #' @param p A named list of parameters for the spatial kernel.
 #' @param hawkes A `hawkes` object.
@@ -19,7 +20,7 @@
 #' @param x_diff A matrix of pairwise x-coordinate differences.
 #' @param y_diff A matrix of pairwise y-coordinate differences.
 #'
-#' @returns The negative log-likelihood contribution of the spatial triggering parameters.
+#' @returns The negative log-likelihood contribution of the spatial parameters.
 #' @keywords internal
 .spatial_parameter_likelihood <- function(p, hawkes, parent_est_mat, x_diff, y_diff) {
   # Extract all hawkes object attributes
@@ -47,16 +48,17 @@
 }
 
 
-#' Temporal triggering kernel parameter likelihood
+#' Temporal kernel likelihood contribution
 #'
-#' Computes the (negative) expected complete-data log-likelihood for temporal triggering kernel parameters.
+#' Evaluates the negative expected complete-data log-likelihood for temporal triggering
+#' kernels.
 #'
 #' @param p A named list of parameters for the temporal kernel.
 #' @param hawkes A `hawkes` object.
 #' @param parent_est_mat Matrix of estimated parent probabilities.
 #' @param time_diff A matrix of pairwise time differences.
 #'
-#' @returns The negative log-likelihood contribution of the temporal triggering parameters.
+#' @returns The negative log-likelihood contribution of the temporal parameters.
 #' @keywords internal
 .temporal_parameter_likelihood <- function(p, hawkes, parent_est_mat, time_diff, triggering_rate) {
   # Extract all hawkes object attributes
@@ -87,9 +89,10 @@
 }
 
 
-#' Optimize kernel parameters with named list support
+#' Optimize kernel parameters from named lists
 #'
-#' Optimizes a likelihood function using `optim()` with parameters passed as a named list. Only non-fixed parameters are estimated.
+#' Uses `optim()` to minimize a likelihood while accepting parameters stored in named
+#' lists. Only parameters not marked as fixed are updated.
 #'
 #' @param fn The objective function to minimize, taking a list of named parameters.
 #' @param param_list A named list of parameter lists (e.g., with components `spatial`, `temporal`).

--- a/R/maximum_likelihood_estimation.R
+++ b/R/maximum_likelihood_estimation.R
@@ -1,23 +1,41 @@
 
 #' Parent Matrix Estimation
 #'
-#' @param hawkes A `hawkes` object
-#' @param parameters A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function.
+#' @param hawkes A `hawkes` object.
+#' @param parameters Named list containing background, triggering, spatial, and temporal
+#'   parameters. Values usually represent current estimates.
 #'
 #' @returns A numeric matrix
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #'
 #' (parent_est_mat <- parent_est(hawkes, params))
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 0)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 0
+#' )
 #'
 #' (parent_est_mat <- parent_est(hawkes, params))
 parent_est <- function(hawkes, parameters) {
@@ -98,23 +116,31 @@ parent_est <- function(hawkes, parameters) {
   parent_mat
 }
 
-#' Compute Parameter Estimate Updates
+#' Compute parameter estimate updates
 #'
-#' @param hawkes A `hawkes` object
-#' @param parameters A named list of lists containing the values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function. If some parameters in the kernel function should be fixed in estimation, pass their names as another named list within params as fixed$spatial = c("mean").
-#' @param parent_est_mat A matrix produced from the parent_est_mat() function.
-#' @param boundary A boundary region to correct for the boundary bias. Defaults to NULL if not used.
-#' @param fixed_spatial A character vector of the spatial parameters to fix in parameter estimation. Defaults to NULL if not used
-#' @param fixed_temporal A character vector of the temporal parameters to fix in parameter estimation. Defaults to NULL if not used
+#' @param hawkes A `hawkes` object.
+#' @param parameters Named list containing background, triggering, spatial, and temporal
+#'   parameters. To fix kernel parameters, include a `fixed` list such as
+#'   `fixed$spatial = c("mean")`.
+#' @param parent_est_mat Matrix returned by `parent_est()`.
+#' @param boundary Optional boundary width used to correct edge bias.
+#' @param fixed_spatial Optional character vector naming spatial parameters to hold fixed.
+#' @param fixed_temporal Optional character vector naming temporal parameters to hold
+#'   fixed.
 #'
-#' @returns A named list of the form of parameters with udpated parameter estimates.
+#' @returns A named list mirroring `parameters` with updated estimates.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' parent_est_mat <- parent_est(hawkes, params)
 #' est_params(hawkes, params, parent_est_mat)
 #'
@@ -246,28 +272,47 @@ est_params <- function(hawkes, parameters, parent_est_mat, boundary = NULL, fixe
 
 
 
-#' Function to Estimate MLEs
+#' Function to estimate MLEs
 #'
-#' @param hawkes A `hawkes` object
-#' @param inits A named list of lists containing the initial values for the background rate, triggering ratio, spatial parameters in a named list, and temporal parameters in a named list. Note that these values are of the same form as the true values in the Hawkes object but are often estimates passed to the function. If some parameters in the kernel function should be fixed in estimation, pass their names as another named list within params as fixed$spatial = c("mean").
-#' @param boundary A boundary region to correct for the boundary bias. Defaults to NULL if not used.
-#' @param max_iters A numeric value for the maximum number of iteration in the EM-algorithm. Defaults to 500 if not used.
-#' @param verbose A logical to specify if parameter estimates should be printed at each iteration of the EM-algorithm.
+#' @param hawkes A `hawkes` object.
+#' @param inits Named list of initial background, triggering, spatial, and temporal
+#'   parameters. To fix parameters, include a `fixed` list such as
+#'   `fixed$spatial = c("mean")`.
+#' @param boundary Optional boundary width used for edge correction.
+#' @param max_iters Maximum number of EM iterations. Defaults to 500.
+#' @param verbose Logical flag to print parameter updates during fitting.
 #'
-#' @returns A `hawkes_fit` object that is a list of lists containing the MLEs.
+#' @returns A `hawkes_fit` object containing the MLEs.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.5,spatial = list(mean = 0, sd = .1),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,100), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.1),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 100), spatial_region = spatial_region)
 #' hawkes_mle(hawkes, inits = params)
 #'
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' hawkes_mle(hawkes, inits = params, boundary = 1)
 hawkes_mle <- function(hawkes, inits, boundary = NULL, max_iters = 500, verbose = FALSE) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
@@ -339,30 +384,33 @@ hawkes_mle <- function(hawkes, inits, boundary = NULL, max_iters = 500, verbose 
 
 
 
-#' Estimate the covariance matrix of the MLE using the observed information
+#' Estimate the covariance matrix of the MLE using observed information
 #'
-#' Computes the observed information matrix (negative Hessian of the log-likelihood)
-#' and returns its inverse as an estimate of the covariance matrix for the MLE parameters
-#' in a spatio-temporal Hawkes process model.
+#' Computes the observed information matrix (negative Hessian of the log-likelihood) and
+#' returns its inverse as an estimated covariance matrix for Hawkes model parameters.
 #'
-#' @param hawkes A hawkes object.
-#' @param est A hawkes_fit object from the `hawkes_mle()` function.
+#' @param hawkes A `hawkes` object.
+#' @param est A `hawkes_fit` object from `hawkes_mle()`.
 #'
 #' @return A named covariance matrix corresponding to the estimated parameters.
 #'
-#' @details This function requires the \pkg{numDeriv} package. It numerically approximates the
-#' Hessian of the full log-likelihood using central differences and inverts the negative Hessian
-#' to obtain the covariance estimate. The names of the matrix rows and columns are set to match
-#' the flattened parameter vector.
+#' @details Requires the \pkg{numDeriv} package. The Hessian of the full log-likelihood is
+#'   approximated with central differences. The negative Hessian is inverted and its row and
+#'   column names are matched to the flattened parameter vector.
 #'
 #' @importFrom numDeriv hessian
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' hessian_est(hawkes, est$est)
 #'

--- a/R/plot_hawkes.R
+++ b/R/plot_hawkes.R
@@ -1,27 +1,50 @@
 
 #' Plot Hawkes Process Points
 #'
-#' Creates a scatterplot of points from a spatio-temporal Hawkes process, colored either by time or by whether they are background events.
+#' Creates a scatter plot of Hawkes events colored by time or background status.
 #'
 #' @param hawkes A `hawkes` object
-#' @param color A string, either `"time"` to color by time, or `"background"` to color by whether an event is a background event (only works for simulated processes).
-#' @param ... Additional arguments passed to `ggplot2::geom_sf(data = hawkes, ...)`. For full customization directly use ggplot() + geom_sf()
+#' @param color Either `"time"` to color by event time or `"background"` to show
+#'   simulated background events.
+#' @param ... Additional arguments forwarded to `ggplot2::geom_sf()`.
 #'
 #' @return A `ggplot2` object.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region, spatial_burnin = 1)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(
+#'   params,
+#'   time_window = c(0, 50),
+#'   spatial_region = spatial_region,
+#'   spatial_burnin = 1
+#' )
 #'
 #' plot_hawkes(hawkes, color = "time")
 #'
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #'
 #' plot_hawkes(hawkes, color = "time")
 plot_hawkes <- function(hawkes, color = "time",...) {
@@ -61,38 +84,55 @@ plot_hawkes <- function(hawkes, color = "time",...) {
 }
 
 
-#' Plot Conditional Intensity of Hawkes Process
+#' Plot conditional intensity of a Hawkes process
 #'
-#' Visualizes the conditional intensity function at a fixed time over a spatial grid, based on a fitted Hawkes model.
+#' Visualizes the conditional intensity over space or time given a fitted Hawkes model.
 #'
 #' @param hawkes A `hawkes` object
 #' @param est A list of fitted parameter values for the Hawkes process.
 #' @param stepsize A numeric value for the spatial resolution of the evaluation grid.
 #' @param time A numeric value giving the time at which to evaluate the conditional intensity.
-#' @param coordinates A numeric vector of length 2 specifying the coordinates where to evalute the conditional intensity over time.
+#' @param coordinates Numeric vector of length two giving the evaluation location.
 #'
-#' @return A list of `ggplot2` objects showing the spatial intensity and temporal intensity at a given time or location.
+#' @return A list of `ggplot2` objects showing spatial and temporal intensity views.
 #' @export
 #'
 #' @examples
 #' # example code
 #' set.seed(123)
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 #'
-#' plot_intensity(hawkes, est, stepsize = .25, time = 40)
-#' plot_intensity(hawkes, est, stepsize = .25, coordinates = c(5,5))
-#' plot_intensity(hawkes, est, stepsize = .25, coordinates = c(5,5), time = 40)
+#' plot_intensity(hawkes, est, stepsize = 0.25, time = 40)
+#' plot_intensity(hawkes, est, stepsize = 0.25, coordinates = c(5, 5))
+#' plot_intensity(hawkes, est, stepsize = 0.25, coordinates = c(5, 5), time = 40)
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = c(.5, 3))
 #' plot_hawkes(hawkes)
-#' plot_intensity(hawkes, est, stepsize = .1, time = 40, coordinates = c(4.5, 5))
+#' plot_intensity(hawkes, est, stepsize = 0.1, time = 40, coordinates = c(4.5, 5))
 plot_intensity <- function(hawkes, est, stepsize, time = NULL, coordinates = NULL) {
   plots <- list()
 

--- a/R/rHawkes.R
+++ b/R/rHawkes.R
@@ -22,10 +22,11 @@ create_rectangular_sf <- function(xmin, xmax, ymin, ymax, crs = NA) {
 
 #' Simulate background events
 #'
-#' @param background_rate A vector of coefficients for the background covariates.
-#' @param time_window A numeric vector of length 2 specifying the simulated time window.
-#' @param spatial_region An sf object defining the spatial region for simulation.
-#' @param covariate_columns A character vector of the names of the columns in spatial_region to be used as background covariates.
+#' @param background_rate Vector of coefficients for the background covariates.
+#' @param time_window Numeric vector of length two giving the simulated time window.
+#' @param spatial_region `sf` object defining the simulation region.
+#' @param covariate_columns Optional character vector naming background covariates in
+#'   `spatial_region`.
 #'
 #' @importFrom stats rnorm rpois rexp runif
 #'
@@ -33,8 +34,8 @@ create_rectangular_sf <- function(xmin, xmax, ymin, ymax, crs = NA) {
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
-#' time_window <- c(0,50)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
+#' time_window <- c(0, 50)
 #' background_rate <- -4
 #'
 #' sim_background_events(background_rate, time_window, spatial_region)
@@ -112,16 +113,20 @@ sim_background_events <- function(background_rate, time_window, spatial_region, 
 
 
 
-#' Generate a Hawkes Process
+#' Generate a Hawkes process
 #'
-#' @param params A named list of lists containing the values for the background rate, triggering rate, spatial parameters in a named list, and temporal parameters in a named list. See example for exact specification.
-#' @param time_window A numeric vector of length 2 specifying the simulated time window.
-#' @param spatial_region An sf object defining the spatial region for simulation.
-#' @param covariate_columns A character vector of the names of the columns in spatial_region to be used as background covariates.
-#' @param temporal_burnin Temporal burn-in for simulation. Defaults to 1/10 of the length of the time window if not used.
-#' @param spatial_burnin Spatial burn-in for simulation. Defaults to the area of spatial_region^.25.
-#' @param temporal_family A temporal triggering kernel function to generate data from. Defaults to "Exponential" if not used. Other options include "Power Law", "Uniform", and "Gamma".
-#' @param spatial_family A spatial triggering kernel function to generate data from. Defaults to "Gaussian" if not used. Other options include "Uniform" and "Exponential"
+#' @param params Named list containing background, triggering, spatial, and temporal
+#'   parameters. See the examples for the expected structure.
+#' @param time_window Numeric vector of length two specifying the simulated window.
+#' @param spatial_region `sf` object defining the spatial region.
+#' @param covariate_columns Optional character vector naming background covariates.
+#' @param temporal_burnin Temporal burn-in duration. Defaults to one tenth of the window
+#'   length.
+#' @param spatial_burnin Spatial burn-in radius. Defaults to `area(spatial_region)^0.25`.
+#' @param temporal_family Temporal triggering kernel. Defaults to "Exponential". Other
+#'   options include "Power Law", "Uniform", and "Gamma".
+#' @param spatial_family Spatial triggering kernel. Defaults to "Gaussian". Other options
+#'   include "Uniform" and "Exponential".
 #'
 #' @importFrom stats rnorm rpois rexp runif
 #'
@@ -129,14 +134,36 @@ sim_background_events <- function(background_rate, time_window, spatial_region, 
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' (hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region, spatial_burnin = 1))
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' (hawkes <- rHawkes(
+#'   params,
+#'   time_window = c(0, 50),
+#'   spatial_region = spatial_region,
+#'   spatial_burnin = 1
+#' ))
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 rHawkes <- function(params, time_window, spatial_region, covariate_columns = NULL,
                     temporal_burnin = (time_window[2] - time_window[1]) / (10), spatial_burnin = sum(sf::st_area(spatial_region) |> as.numeric())^.25,
                     temporal_family = "Exponential", spatial_family = "Gaussian") {

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -1,28 +1,61 @@
-#' Compute Time Scaled Residuals
+#' Compute time-scaled residuals
 #'
-#' @param hawkes a `hawkes` object
-#' @param est a `hawkes_mle` object produced from `hawkes_mle()`.
+#' @param hawkes A `hawkes` object.
+#' @param est A `hawkes_mle` object produced by `hawkes_mle()`.
 #'
 #' @returns A numeric vector of transformed waiting times.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.5,spatial = list(mean = 0, sd = .1),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,100), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.1),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 100), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' residuals <- time_scaled_residuals(hawkes, est)
 #'
-#' curve(dexp(x, rate = 1), from = 0, to = 10, lwd = 2, xlab = "Residual", ylab = "Density", main = "Residual vs Exponential(1)")
+#' curve(
+#'   dexp(x, rate = 1),
+#'   from = 0,
+#'   to = 10,
+#'   lwd = 2,
+#'   xlab = "Residual",
+#'   ylab = "Density",
+#'   main = "Residual vs Exponential(1)"
+#' )
 #' lines(density(residuals, from = 0), col = "red")
 #'
-#' params <- list(background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),triggering_rate = 0.5,spatial = list(mean = 0, sd = .25),temporal = list(rate = 2), fixed = list(spatial = "mean"))
+#' params <- list(
+#'   background_rate = list(intercept = -4.5, X1 = 1, X2 = 1),
+#'   triggering_rate = 0.5,
+#'   spatial = list(mean = 0, sd = 0.25),
+#'   temporal = list(rate = 2),
+#'   fixed = list(spatial = "mean")
+#' )
 #' data("example_background_covariates")
-#' hawkes <- rHawkes(params, c(0,50), example_background_covariates, covariate_columns = c("X1", "X2"), spatial_burnin = 1)
+#' hawkes <- rHawkes(
+#'   params,
+#'   c(0, 50),
+#'   example_background_covariates,
+#'   covariate_columns = c("X1", "X2"),
+#'   spatial_burnin = 1
+#' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 #'
-#' curve(dexp(x, rate = 1), from = 0, to = 10, lwd = 2, xlab = "Residual", ylab = "Density", main = "Residual vs Exponential(1)")
+#' curve(
+#'   dexp(x, rate = 1),
+#'   from = 0,
+#'   to = 10,
+#'   lwd = 2,
+#'   xlab = "Residual",
+#'   ylab = "Density",
+#'   main = "Residual vs Exponential(1)"
+#' )
 #' lines(density(residuals, from = 0), col = "red")
 time_scaled_residuals <- function(hawkes, est) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")

--- a/R/subsample.R
+++ b/R/subsample.R
@@ -1,16 +1,21 @@
 #' Resample data with moving blocls
 #'
-#' @param hawkes A `hawkes` object
-#' @param length A numeric value to set the length of the subsample.
+#' @param hawkes A `hawkes` object.
+#' @param length Length of the temporal subsample.
 #'
 #' @returns A `hawkes` object.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' sample_subregion(hawkes, 25)
 #'
@@ -54,25 +59,30 @@ sample_subregion <- function(hawkes, length) {
               temporal_family = temporal_family)
 }
 
-#' Block Bootstrap for COnfidence Intervals of Hawkes MLEs
+#' Block bootstrap for Hawkes MLEs via subsampling
 #'
-#' @param hawkes A `hawkes` object
-#' @param est A `hawkes_est` object containing the parameter estimates of `hawkes`
-#' @param B number of bootstrap iterations
-#' @param length A numeric value to set the length of the subsample
-#' @param alpha type-1 error rate for constructing confidence intervals. Defaults to .05 if unused
-#' @param parallel a logical specifying if parallel computation should be used. Parallel computation is implemented with the `furrr` package.
-#' @param max_iters maximum number of iterations to use in maximum likelihood estimation. Defaults to 500 if unused.
-#' @param boundary size of boundary to use for border correction. Defaults to NULL if unused
+#' @param hawkes A `hawkes` object.
+#' @param est A `hawkes_est` object containing parameter estimates.
+#' @param B Number of bootstrap iterations.
+#' @param length Length of each temporal subsample.
+#' @param alpha Type I error rate for confidence intervals. Defaults to 0.05.
+#' @param parallel Logical flag for `furrr` based parallel computation.
+#' @param max_iters Maximum EM iterations per fit. Defaults to 500.
+#' @param boundary Optional boundary width used for edge correction.
 #'
-#' @returns A `hawkes` object.
+#' @returns A tibble of bootstrap estimates.
 #' @export
 #'
 #' @examples
-#' spatial_region <- create_rectangular_sf(0,10,0,10)
+#' spatial_region <- create_rectangular_sf(0, 10, 0, 10)
 #'
-#' params <- list(background_rate = list(intercept = -4),triggering_rate = 0.75,spatial = list(mean = 0, sd = .75),temporal = list(rate = 2))
-#' hawkes <- rHawkes(params, time_window = c(0,50), spatial_region = spatial_region)
+#' params <- list(
+#'   background_rate = list(intercept = -4),
+#'   triggering_rate = 0.75,
+#'   spatial = list(mean = 0, sd = 0.75),
+#'   temporal = list(rate = 2)
+#' )
+#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' subsample(hawkes, est, 5, 25, alpha = 0.05)
 subsample <- function(hawkes, est, B, length, alpha, parallel = FALSE, max_iters = 500, boundary = NULL) {


### PR DESCRIPTION
## Summary
- shorten Hawkes bootstrap helper documentation and examples so lines stay within 100 characters
- clean up simulation, estimation, and plotting roxygen text throughout the package for consistent concise descriptions

## Testing
- `Rscript -e "roxygen2::roxygenise()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4251b8a08329ba2d4bd3017ff901