### PR TITLE
Improve hawkes_fit summary reporting

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(confint,hawkes_fit)
 S3method(print,hawkes)
 S3method(print,hawkes_fit)
+S3method(print,summary.hawkes_fit)
 S3method(summary,hawkes_fit)
 export(.vector_input_log_likelihood)
 export(as_hawkes)

--- a/R/hawkes_fit.R
+++ b/R/hawkes_fit.R
@@ -10,11 +10,12 @@ new_hawkes_fit <- function(hawkes, est) {
 
   structure(
     list(
+      est = est,
       estimate = est,
+      hawkes = hawkes,
       hawkes_object = hawkes,
       residuals = time_scaled_residuals(hawkes, est)
     ),
-    # est,
     class = c("hawkes_fit", class(est))
   )
 }
@@ -72,9 +73,9 @@ new_hawkes_fit <- function(hawkes, est) {
 #' est <- hawkes_mle(hawkes, inits = params)
 #' confint(est)
 confint.hawkes_fit <- function(object, parm = NULL, level = 0.95, ...) {
-  hawkes <- object$hawkes
+  hawkes <- if (!is.null(object$hawkes_object)) object$hawkes_object else object$hawkes
 
-  est <- object$est
+  est <- if (!is.null(object$estimate)) object$estimate else object$est
 
   alpha <- 1 - level
 
@@ -112,7 +113,7 @@ confint.hawkes_fit <- function(object, parm = NULL, level = 0.95, ...) {
 #' @export
 #'
 print.hawkes_fit <- function(x, ...) {
-  est <- x$est
+  est <- if (!is.null(x$estimate)) x$estimate else x$est
   cat("Triggering Parameter Estimates:\n")
 
   cat("Background Rate (\u03B2):   \n")
@@ -137,33 +138,118 @@ print.hawkes_fit <- function(x, ...) {
 
 #' Print hawkes fit object
 #'
-#' @param object a hawkes fit object to be printed
+#' @param object a hawkes fit object to be summarized.
+#' @param level Confidence level used for interval estimates. Default is 0.95.
+#' @param digits Minimum number of significant digits to print.
 #' @param ... Further arguments passed to or from other methods.
+#'
+#' @return An object of class `summary.hawkes_fit` containing the coefficient table,
+#'   residual summary, and the confidence level used.
 #'
 #' @export
 #'
-summary.hawkes_fit <- function(object, ...){
-  conf_int <- confint(object)
+summary.hawkes_fit <- function(object, level = 0.95, digits = max(3L, getOption("digits") - 3L), ...) {
+  if (!inherits(object, "hawkes_fit")) {
+    stop("`object` must be a `hawkes_fit`.")
+  }
 
-  cat("Background Coefficients:\n")
-  conf_int |>
-    dplyr::filter(stringr::str_detect(.data$Variable, "^background_rate")) |>
-    dplyr::mutate(Variable = stringr::str_remove(.data$Variable, "^background_rate.")) |>
-    dplyr::rename(Coefficient = .data$Variable,
-                  `Std. Error` = .data$std_error,
-                  `95% Lower Bound` = .data$Lower,
-                  `95% Upper Bound` = .data$Upper) |>
-    print()
-  cat("\n")
-  cat("Trigering Coefficients:\n")
-  conf_int |>
-    dplyr::filter(!stringr::str_detect(.data$Variable, "^background_rate")) |>
-    dplyr::mutate(Variable = stringr::str_remove(.data$Variable, "^background_rate.")) |>
-    dplyr::rename(Coefficient = .data$Variable,
-                  `Std. Error` = .data$std_error,
-                  `95% Lower Bound` = .data$Lower,
-                  `95% Upper Bound` = .data$Upper) |>
-    print()
+  est <- if (!is.null(object$estimate)) object$estimate else object$est
+
+  if (is.null(est)) {
+    stop("Hawkes fit object does not contain parameter estimates.")
+  }
+
+  conf_tbl <- confint(object, level = level, ...)
+
+  if (is.null(object$residuals) && !is.null(object$hawkes_object)) {
+    residuals <- time_scaled_residuals(object$hawkes_object, est)
+  } else {
+    residuals <- object$residuals
+  }
+
+  if (!is.null(residuals)) {
+    residual_summary <- stats::quantile(residuals, probs = c(0, 0.25, 0.5, 0.75, 1), na.rm = TRUE)
+    names(residual_summary) <- c("Min", "1Q", "Median", "3Q", "Max")
+  } else {
+    residual_summary <- NULL
+  }
+
+  conf_df <- as.data.frame(conf_tbl)
+
+  parts <- stringr::str_split_fixed(conf_df$Variable, "\\.", 2)
+
+  component_raw <- parts[, 1]
+  term_raw <- ifelse(parts[, 2] == "", parts[, 1], parts[, 2])
+
+  label_fun <- function(x) {
+    tools::toTitleCase(gsub("_", " ", x, fixed = TRUE))
+  }
+
+  row_labels <- ifelse(
+    component_raw == term_raw,
+    label_fun(component_raw),
+    paste(label_fun(component_raw), label_fun(term_raw), sep = ": ")
+  )
+
+  component_levels <- c("background_rate", "triggering_rate", "spatial", "temporal")
+  component_rank <- match(component_raw, component_levels)
+  if (any(is.na(component_rank))) {
+    next_rank <- max(component_rank, na.rm = TRUE)
+    if (!is.finite(next_rank)) {
+      next_rank <- 0
+    }
+    component_rank[is.na(component_rank)] <- next_rank + seq_len(sum(is.na(component_rank)))
+  }
+
+  order_idx <- order(component_rank, row_labels)
+  conf_df <- conf_df[order_idx, , drop = FALSE]
+  row_labels <- row_labels[order_idx]
+
+  alpha <- 1 - level
+  lower_col <- paste0(formatC(100 * alpha / 2, format = "f", digits = 1), "%")
+  upper_col <- paste0(formatC(100 * (1 - alpha / 2), format = "f", digits = 1), "%")
+
+  coef_mat <- as.matrix(conf_df[, c("Estimate", "std_error", "Lower", "Upper")])
+  colnames(coef_mat) <- c("Estimate", "Std. Error", lower_col, upper_col)
+  rownames(coef_mat) <- row_labels
+
+  n_obs <- NA_integer_
+  if (!is.null(object$hawkes_object)) {
+    n_obs <- nrow(object$hawkes_object)
+  } else if (!is.null(object$hawkes)) {
+    n_obs <- nrow(object$hawkes)
+  }
+
+  out <- list(
+    coefficients = coef_mat,
+    conf.level = level,
+    residual_summary = residual_summary,
+    digits = digits,
+    n = n_obs
+  )
+
+  class(out) <- "summary.hawkes_fit"
+  out
+}
+
+#' @rdname summary.hawkes_fit
+#' @export
+print.summary.hawkes_fit <- function(x, digits = x$digits, ...) {
+  if (!is.null(x$n) && is.finite(x$n)) {
+    cat(sprintf("Number of events: %s\n\n", x$n))
+  }
+
+  if (!is.null(x$residual_summary)) {
+    cat("Residuals:\n")
+    print.default(x$residual_summary, digits = digits)
+    cat("\n")
+  }
+
+  cat("Coefficients:\n")
+  stats::printCoefmat(x$coefficients, digits = digits, has.Pvalue = FALSE)
+  cat(sprintf("\nConfidence level used: %.1f%%\n", 100 * x$conf.level))
+
+  invisible(x)
 }
 #
 

--- a/man/summary.hawkes_fit.Rd
+++ b/man/summary.hawkes_fit.Rd
@@ -2,15 +2,29 @@
 % Please edit documentation in R/hawkes_fit.R
 \name{summary.hawkes_fit}
 \alias{summary.hawkes_fit}
-\title{Print hawkes fit object}
+\alias{print.summary.hawkes_fit}
+\title{Summarize a hawkes fit object}
 \usage{
-\method{summary}{hawkes_fit}(object, ...)
+\method{summary}{hawkes_fit}(object, level = 0.95, digits = max(3L, getOption("digits") - 3L), ...)
+
+\method{print}{summary.hawkes_fit}(x, digits = x$digits, ...)
 }
 \arguments{
-\item{object}{a hawkes fit object to be printed}
+\item{object}{a hawkes fit object to be summarized.}
 
-\item{...}{Further arguments passed to or from other methods.}
+\item{level}{confidence level used when constructing confidence intervals.}
+
+\item{digits}{minimum number of significant digits to display.}
+
+\item{...}{further arguments passed to or from other methods.}
+
+\item{x}{an object of class \code{summary.hawkes_fit}.}
+}
+\value{
+An object of class \code{summary.hawkes_fit} containing the coefficient table, residual
+summary, and the confidence level used.
 }
 \description{
-Print hawkes fit object
+Summarizes a fitted Hawkes model by reporting parameter estimates with Wald confidence
+intervals and basic residual diagnostics.
 }


### PR DESCRIPTION
## Summary
- add compatibility fields to `hawkes_fit` objects for downstream methods
- rework `summary.hawkes_fit` to provide glm-style coefficient and residual output with confidence intervals
- add a `print.summary.hawkes_fit` method, register it in the namespace, and update documentation

## Testing
- `Rscript -e 'source("R/hawkes_fit.R")'` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4f0202b083298e4a428346970a18