### PR TITLE
Reorder Hawkes argument order and align formula handling

### DIFF
--- a/R/block_bootstrap.R
+++ b/R/block_bootstrap.R
@@ -17,10 +17,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' extend_data_t_only(hawkes, 5)
@@ -80,10 +80,10 @@ extend_data_t_only <- function(hawkes, block_length_t) {
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #'
@@ -157,10 +157,10 @@ sample_blocks <- function(hawkes, num_blocks) {
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/R/cluster_bootstrap.R
+++ b/R/cluster_bootstrap.R
@@ -17,10 +17,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
@@ -158,10 +158,10 @@ sample_clusters <- function(hawkes, parent_mat, boundary = NULL) {
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/R/hawkes_fit.R
+++ b/R/hawkes_fit.R
@@ -50,7 +50,7 @@ new_hawkes_fit <- function(hawkes, est) {
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' confint(est)
 #'
@@ -64,10 +64,10 @@ new_hawkes_fit <- function(hawkes, est) {
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 0
 #' )
 #' est <- hawkes_mle(hawkes, inits = params)

--- a/R/likelihood_functions.R
+++ b/R/likelihood_functions.R
@@ -16,7 +16,7 @@
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' conditional_intensity(hawkes, params)
 conditional_intensity <- function(hawkes, parameters) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
@@ -111,7 +111,7 @@ conditional_intensity <- function(hawkes, parameters) {
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' spatial_conditional_intensity(hawkes, params, 25, 0.5)
 #'
 #' params <- list(
@@ -123,10 +123,10 @@ conditional_intensity <- function(hawkes, parameters) {
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #'
@@ -236,7 +236,7 @@ spatial_conditional_intensity <- function(hawkes, parameters, time, stepsize) {
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' temporal_conditional_intensity(hawkes, params, c(5, 5))
 temporal_conditional_intensity <- function(hawkes, parameters, coordinates, step = .1) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
@@ -342,7 +342,7 @@ temporal_conditional_intensity <- function(hawkes, parameters, coordinates, step
 #'   spatial = list(mean = 0, sd = 0.5),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, c(0, 50), spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' log_likelihood(hawkes, params)
 log_likelihood <- function(hawkes, parameters) {
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")

--- a/R/maximum_likelihood_estimation.R
+++ b/R/maximum_likelihood_estimation.R
@@ -17,7 +17,7 @@
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #'
 #' (parent_est_mat <- parent_est(hawkes, params))
 #'
@@ -30,10 +30,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 0
 #' )
 #'
@@ -140,7 +140,7 @@ parent_est <- function(hawkes, parameters) {
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' parent_est_mat <- parent_est(hawkes, params)
 #' est_params(hawkes, params, parent_est_mat)
 #'
@@ -275,6 +275,8 @@ est_params <- function(hawkes, parameters, parent_est_mat, boundary = NULL, fixe
 #' Function to estimate MLEs
 #'
 #' @param hawkes A `hawkes` object.
+#' @param background_process One-sided formula specifying background covariates. When
+#'   omitted, any existing covariate metadata stored on `hawkes` is reused.
 #' @param inits Named list of initial background, triggering, spatial, and temporal
 #'   parameters. To fix parameters, include a `fixed` list such as
 #'   `fixed$spatial = c("mean")`.
@@ -294,8 +296,13 @@ est_params <- function(hawkes, parameters, parent_est_mat, boundary = NULL, fixe
 #'   spatial = list(mean = 0, sd = 0.1),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 100), spatial_region = spatial_region)
-#' hawkes_mle(hawkes, inits = params)
+#' hawkes <- rHawkes(
+#'   params = params,
+#'   time_window = c(0, 100),
+#'   spatial_region = spatial_region,
+#'   background_process = ~ 1
+#' )
+#' hawkes_mle(hawkes, ~ 1, inits = params)
 #'
 #'
 #' params <- list(
@@ -307,14 +314,17 @@ est_params <- function(hawkes, parameters, parent_est_mat, boundary = NULL, fixe
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
-#' hawkes_mle(hawkes, inits = params, boundary = 1)
-hawkes_mle <- function(hawkes, inits, boundary = NULL, max_iters = 500, verbose = FALSE) {
+#' hawkes_mle(hawkes, ~ X1 + X2, inits = params, boundary = 1)
+hawkes_mle <- function(hawkes, background_process = ~ 1, inits, boundary = NULL, max_iters = 500, verbose = FALSE) {
+  if (!missing(background_process)) {
+    attr(hawkes, "covariate_columns") <- .background_formula_columns(background_process)
+  }
   if(class(hawkes)[1] != "hawkes") stop("hawkes must be a hawkes object")
 
   .sanity_check(hawkes)
@@ -410,7 +420,7 @@ hawkes_mle <- function(hawkes, inits, boundary = NULL, max_iters = 500, verbose 
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' hessian_est(hawkes, est$est)
 #'

--- a/R/parametric_bootstrap.R
+++ b/R/parametric_bootstrap.R
@@ -25,10 +25,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
@@ -46,10 +46,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
@@ -94,12 +94,15 @@ parametric_bootstrap <- function(hawkes, est, B, alpha = 0.05, parallel = FALSE,
   n_failed <- 0
 
   boot_ests <- furrr::future_map_dfr(1:B, ~ tryCatch({
-    sample <- rHawkes(est$est, time_window, spatial_region,
-                      covariate_columns = covariate_columns,
-                      temporal_burnin = temporal_burnin,
-                      spatial_burnin = spatial_burnin,
-                      spatial_family = spatial_family,
-                      temporal_family = temporal_family)
+    sample <- rHawkes(
+      hawkes = hawkes,
+      background_process = .background_columns_to_formula(covariate_columns),
+      params = est$est,
+      temporal_burnin = temporal_burnin,
+      spatial_burnin = spatial_burnin,
+      spatial_family = spatial_family,
+      temporal_family = temporal_family
+    )
 
     # Estimate the parameters on each bootstrapped sample and transform to long tibble
     boot_est <- hawkes_mle(sample, inits = est$est, boundary = boundary, max_iters = max_iters)
@@ -120,10 +123,15 @@ parametric_bootstrap <- function(hawkes, est, B, alpha = 0.05, parallel = FALSE,
 
   } else{
     boot_samples <- purrr::map(1:B, ~ {
-      sample <-  rHawkes(est$est, time_window, spatial_region,
-                         covariate_columns = covariate_columns,
-                         temporal_burnin = temporal_burnin, spatial_burnin = spatial_burnin,
-                         spatial_family = spatial_family, temporal_family = temporal_family)
+      sample <- rHawkes(
+        hawkes = hawkes,
+        background_process = .background_columns_to_formula(covariate_columns),
+        params = est$est,
+        temporal_burnin = temporal_burnin,
+        spatial_burnin = spatial_burnin,
+        spatial_family = spatial_family,
+        temporal_family = temporal_family
+      )
     })
     n_failed <- 0
     boot_ests <- purrr::imap_dfr(boot_samples, ~ tryCatch({

--- a/R/plot_hawkes.R
+++ b/R/plot_hawkes.R
@@ -39,10 +39,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #'
@@ -108,7 +108,7 @@ plot_hawkes <- function(hawkes, color = "time",...) {
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 #'
 #' plot_intensity(hawkes, est, stepsize = 0.25, time = 40)
@@ -124,10 +124,10 @@ plot_hawkes <- function(hawkes, color = "time",...) {
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = c(.5, 3))

--- a/R/rHawkes.R
+++ b/R/rHawkes.R
@@ -37,6 +37,31 @@ create_rectangular_sf <- function(xmin, xmax, ymin, ymax, covariates = NULL, n_g
     cbind(covariates)
 }
 
+.background_formula_columns <- function(background_process) {
+  if (missing(background_process) || is.null(background_process)) {
+    return(NULL)
+  }
+
+  if (!inherits(background_process, "formula")) {
+    stop("`background_process` must be a one-sided formula.")
+  }
+
+  if (length(background_process) != 2L) {
+    stop("`background_process` must not include a response term.")
+  }
+
+  cols <- all.vars(background_process)
+  if (length(cols) == 0) NULL else cols
+}
+
+.background_columns_to_formula <- function(covariate_columns) {
+  if (is.null(covariate_columns) || length(covariate_columns) == 0) {
+    stats::as.formula("~ 1")
+  } else {
+    stats::as.formula(paste("~", paste(covariate_columns, collapse = " + ")))
+  }
+}
+
 #' Simulate background events
 #'
 #' @param background_rate Vector of coefficients for the background covariates.
@@ -132,18 +157,24 @@ sim_background_events <- function(background_rate, time_window, spatial_region, 
 
 #' Generate a Hawkes process
 #'
+#' @param hawkes Optional template `hawkes` object supplying process metadata. When
+#'   omitted, `time_window`, `spatial_region`, and kernel families must be provided.
+#' @param background_process One-sided formula specifying background covariates.
+#'   When omitted and `hawkes` is provided, covariate information stored on the
+#'   object is reused.
 #' @param params Named list containing background, triggering, spatial, and temporal
 #'   parameters. See the examples for the expected structure.
 #' @param time_window Numeric vector of length two specifying the simulated window.
-#' @param spatial_region `sf` object defining the spatial region.
-#' @param covariate_columns Optional character vector naming background covariates.
+#'   Defaults to the window stored on `hawkes` when available.
+#' @param spatial_region `sf` object defining the spatial region. Defaults to the
+#'   region stored on `hawkes` when available.
 #' @param temporal_burnin Temporal burn-in duration. Defaults to one tenth of the window
 #'   length.
 #' @param spatial_burnin Spatial burn-in radius. Defaults to `area(spatial_region)^0.25`.
-#' @param temporal_family Temporal triggering kernel. Defaults to "Exponential". Other
-#'   options include "Power Law", "Uniform", and "Gamma".
-#' @param spatial_family Spatial triggering kernel. Defaults to "Gaussian". Other options
-#'   include "Uniform" and "Exponential".
+#' @param temporal_family Temporal triggering kernel. Defaults to the family stored
+#'   on `hawkes` when supplied, otherwise "Exponential".
+#' @param spatial_family Spatial triggering kernel. Defaults to the family stored on
+#'   `hawkes` when supplied, otherwise "Gaussian".
 #'
 #' @importFrom stats rnorm rpois rexp runif
 #'
@@ -160,9 +191,10 @@ sim_background_events <- function(background_rate, time_window, spatial_region, 
 #'   temporal = list(rate = 2)
 #' )
 #' (hawkes <- rHawkes(
-#'   params,
+#'   params = params,
 #'   time_window = c(0, 50),
 #'   spatial_region = spatial_region,
+#'   background_process = ~ 1,
 #'   spatial_burnin = 1
 #' ))
 #'
@@ -175,18 +207,70 @@ sim_background_events <- function(background_rate, time_window, spatial_region, 
 #' )
 #' data("example_background_covariates")
 #' rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
-rHawkes <- function(params, time_window, spatial_region, covariate_columns = NULL,
-                    temporal_burnin = (time_window[2] - time_window[1]) / (10), spatial_burnin = sum(sf::st_area(spatial_region) |> as.numeric())^.25,
-                    temporal_family = "Exponential", spatial_family = "Gaussian") {
+rHawkes <- function(hawkes = NULL, background_process = ~ 1, params, time_window, spatial_region,
+                    temporal_burnin = NULL, spatial_burnin = NULL,
+                    temporal_family = NULL, spatial_family = NULL) {
+  if (!is.null(hawkes) && class(hawkes)[1] != "hawkes") {
+    stop("hawkes must be a hawkes object or NULL.")
+  }
+
+  if (!missing(background_process)) {
+    covariate_columns <- .background_formula_columns(background_process)
+  } else if (!is.null(hawkes)) {
+    covariate_columns <- attr(hawkes, "covariate_columns")
+  } else {
+    covariate_columns <- NULL
+  }
+
+  if (missing(time_window) || is.null(time_window)) {
+    if (!is.null(hawkes)) {
+      time_window <- attr(hawkes, "time_window")
+    } else {
+      stop("time_window must be provided when hawkes is NULL.")
+    }
+  }
+
+  if (missing(spatial_region) || is.null(spatial_region)) {
+    if (!is.null(hawkes)) {
+      spatial_region <- attr(hawkes, "spatial_region")
+    } else {
+      stop("spatial_region must be provided when hawkes is NULL.")
+    }
+  }
+
+  if (is.null(temporal_family)) {
+    if (!is.null(hawkes)) {
+      temporal_family <- attr(hawkes, "temporal_family")
+    } else {
+      temporal_family <- "Exponential"
+    }
+  }
+
+  if (is.null(spatial_family)) {
+    if (!is.null(hawkes)) {
+      spatial_family <- attr(hawkes, "spatial_family")
+    } else {
+      spatial_family <- "Gaussian"
+    }
+  }
+
+  if (is.null(temporal_burnin)) {
+    temporal_burnin <- (time_window[2] - time_window[1]) / (10)
+  }
+
+  if (is.null(spatial_burnin)) {
+    spatial_burnin <- sum(sf::st_area(spatial_region) |> as.numeric())^.25
+  }
+
   # Create empty hawkes object and unpack to assign triggering sampler functions using the hawkes constructor
   hawkes <- hawkes(params = params, time_window = time_window, spatial_region = spatial_region,
-         spatial_family = spatial_family, temporal_family = temporal_family)
+         spatial_family = spatial_family, temporal_family = temporal_family, covariate_columns = covariate_columns)
 
   # Extract all hawkes object attributes
   attrs <- attributes(hawkes)

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -15,7 +15,7 @@
 #'   spatial = list(mean = 0, sd = 0.1),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 100), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 100), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' residuals <- time_scaled_residuals(hawkes, est)
 #'
@@ -39,10 +39,10 @@
 #' )
 #' data("example_background_covariates")
 #' hawkes <- rHawkes(
-#'   params,
-#'   c(0, 50),
-#'   example_background_covariates,
-#'   covariate_columns = c("X1", "X2"),
+#'   params = params,
+#'   time_window = c(0, 50),
+#'   spatial_region = example_background_covariates,
+#'   background_process = ~ X1 + X2,
 #'   spatial_burnin = 1
 #' )
 #' est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/R/subsample.R
+++ b/R/subsample.R
@@ -15,7 +15,7 @@
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' sample_subregion(hawkes, 25)
 #'
@@ -82,7 +82,7 @@ sample_subregion <- function(hawkes, length) {
 #'   spatial = list(mean = 0, sd = 0.75),
 #'   temporal = list(rate = 2)
 #' )
-#' hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+#' hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 #' est <- hawkes_mle(hawkes, inits = params)
 #' subsample(hawkes, est, 5, 25, alpha = 0.05)
 subsample <- function(hawkes, est, B, length, alpha, parallel = FALSE, max_iters = 500, boundary = NULL) {

--- a/man/block_bootstrap.Rd
+++ b/man/block_bootstrap.Rd
@@ -48,10 +48,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/man/cluster_bootstrap.Rd
+++ b/man/cluster_bootstrap.Rd
@@ -45,10 +45,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/man/conditional_intensity.Rd
+++ b/man/conditional_intensity.Rd
@@ -27,6 +27,6 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 conditional_intensity(hawkes, params)
 }

--- a/man/confint.hawkes_fit.Rd
+++ b/man/confint.hawkes_fit.Rd
@@ -36,7 +36,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 est <- hawkes_mle(hawkes, inits = params)
 confint(est)
 
@@ -50,10 +50,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 0
 )
 est <- hawkes_mle(hawkes, inits = params)

--- a/man/est_params.Rd
+++ b/man/est_params.Rd
@@ -44,7 +44,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 parent_est_mat <- parent_est(hawkes, params)
 est_params(hawkes, params, parent_est_mat)
 

--- a/man/extend_data_t_only.Rd
+++ b/man/extend_data_t_only.Rd
@@ -27,10 +27,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 extend_data_t_only(hawkes, 5)

--- a/man/hawkes_mle.Rd
+++ b/man/hawkes_mle.Rd
@@ -4,10 +4,20 @@
 \alias{hawkes_mle}
 \title{Function to estimate MLEs}
 \usage{
-hawkes_mle(hawkes, inits, boundary = NULL, max_iters = 500, verbose = FALSE)
+hawkes_mle(
+  hawkes,
+  background_process = ~1,
+  inits,
+  boundary = NULL,
+  max_iters = 500,
+  verbose = FALSE
+)
 }
 \arguments{
 \item{hawkes}{A \code{hawkes} object.}
+
+\item{background_process}{One-sided formula specifying background covariates. When omitted,
+any existing covariate metadata stored on \code{hawkes} is reused.}
 
 \item{inits}{Named list of initial background, triggering, spatial, and temporal
 parameters. To fix parameters, include a \code{fixed} list such as
@@ -34,8 +44,13 @@ params <- list(
   spatial = list(mean = 0, sd = 0.1),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 100), spatial_region = spatial_region)
-hawkes_mle(hawkes, inits = params)
+hawkes <- rHawkes(
+  params = params,
+  time_window = c(0, 100),
+  spatial_region = spatial_region,
+  background_process = ~1
+)
+hawkes_mle(hawkes, ~1, inits = params)
 
 
 params <- list(
@@ -47,11 +62,11 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
-hawkes_mle(hawkes, inits = params, boundary = 1)
+hawkes_mle(hawkes, ~ X1 + X2, inits = params, boundary = 1)
 }

--- a/man/hessian_est.Rd
+++ b/man/hessian_est.Rd
@@ -32,7 +32,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 est <- hawkes_mle(hawkes, inits = params)
 hessian_est(hawkes, est$est)
 

--- a/man/log_likelihood.Rd
+++ b/man/log_likelihood.Rd
@@ -27,6 +27,6 @@ params <- list(
   spatial = list(mean = 0, sd = 0.5),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, c(0, 50), spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 log_likelihood(hawkes, params)
 }

--- a/man/parametric_bootstrap.Rd
+++ b/man/parametric_bootstrap.Rd
@@ -52,10 +52,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)
@@ -73,10 +73,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/man/parent_est.Rd
+++ b/man/parent_est.Rd
@@ -27,7 +27,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 
 (parent_est_mat <- parent_est(hawkes, params))
 
@@ -40,10 +40,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 0
 )
 

--- a/man/plot_hawkes.Rd
+++ b/man/plot_hawkes.Rd
@@ -48,10 +48,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 

--- a/man/plot_intensity.Rd
+++ b/man/plot_intensity.Rd
@@ -34,7 +34,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)
 
 plot_intensity(hawkes, est, stepsize = 0.25, time = 40)
@@ -50,10 +50,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = c(.5, 3))

--- a/man/rHawkes.Rd
+++ b/man/rHawkes.Rd
@@ -5,36 +5,45 @@
 \title{Generate a Hawkes process}
 \usage{
 rHawkes(
+  hawkes = NULL,
+  background_process = ~1,
   params,
   time_window,
   spatial_region,
-  covariate_columns = NULL,
-  temporal_burnin = (time_window[2] - time_window[1])/(10),
-  spatial_burnin = sum(as.numeric(sf::st_area(spatial_region)))^0.25,
-  temporal_family = "Exponential",
-  spatial_family = "Gaussian"
+  temporal_burnin = NULL,
+  spatial_burnin = NULL,
+  temporal_family = NULL,
+  spatial_family = NULL
 )
 }
 \arguments{
+\item{hawkes}{Optional template \code{hawkes} object supplying process metadata. When
+omitted, \code{time_window}, \code{spatial_region}, and kernel families must be provided.}
+
+\item{background_process}{One-sided formula specifying background covariates. When omitted
+and \code{hawkes} is provided, covariate information stored on the object is reused.}
+
 \item{params}{Named list containing background, triggering, spatial, and temporal
 parameters. See the examples for the expected structure.}
 
-\item{time_window}{Numeric vector of length two specifying the simulated window.}
+\item{time_window}{Numeric vector of length two specifying the simulated window.
+Defaults to the window stored on \code{hawkes} when available.}
 
-\item{spatial_region}{\code{sf} object defining the spatial region.}
-
-\item{covariate_columns}{Optional character vector naming background covariates.}
+\item{spatial_region}{\code{sf} object defining the spatial region. Defaults to the region
+stored on \code{hawkes} when available.}
 
 \item{temporal_burnin}{Temporal burn-in duration. Defaults to one tenth of the window
 length.}
 
 \item{spatial_burnin}{Spatial burn-in radius. Defaults to \code{area(spatial_region)^0.25}.}
 
-\item{temporal_family}{Temporal triggering kernel. Defaults to "Exponential". Other
-options include "Power Law", "Uniform", and "Gamma".}
+\item{temporal_family}{Temporal triggering kernel. Defaults to the family stored on
+\code{hawkes} when supplied, otherwise "Exponential". Other options include
+"Power Law", "Uniform", and "Gamma".}
 
-\item{spatial_family}{Spatial triggering kernel. Defaults to "Gaussian". Other options
-include "Uniform" and "Exponential".}
+\item{spatial_family}{Spatial triggering kernel. Defaults to the family stored on
+\code{hawkes} when supplied, otherwise "Gaussian". Other options include
+"Uniform" and "Exponential".}
 }
 \value{
 A hawkes object with a generated Hawkes process.
@@ -52,9 +61,10 @@ params <- list(
   temporal = list(rate = 2)
 )
 (hawkes <- rHawkes(
-  params,
+  params = params,
   time_window = c(0, 50),
   spatial_region = spatial_region,
+  background_process = ~1,
   spatial_burnin = 1
 ))
 
@@ -67,10 +77,10 @@ params <- list(
 )
 data("example_background_covariates")
 rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 }

--- a/man/sample_blocks.Rd
+++ b/man/sample_blocks.Rd
@@ -27,10 +27,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 

--- a/man/sample_clusters.Rd
+++ b/man/sample_clusters.Rd
@@ -29,10 +29,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/man/sample_subregion.Rd
+++ b/man/sample_subregion.Rd
@@ -26,7 +26,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 est <- hawkes_mle(hawkes, inits = params)
 sample_subregion(hawkes, 25)
 

--- a/man/spatial_conditional_intensity.Rd
+++ b/man/spatial_conditional_intensity.Rd
@@ -31,7 +31,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 spatial_conditional_intensity(hawkes, params, 25, 0.5)
 
 params <- list(
@@ -43,10 +43,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 

--- a/man/subsample.Rd
+++ b/man/subsample.Rd
@@ -47,7 +47,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 est <- hawkes_mle(hawkes, inits = params)
 subsample(hawkes, est, 5, 25, alpha = 0.05)
 }

--- a/man/temporal_conditional_intensity.Rd
+++ b/man/temporal_conditional_intensity.Rd
@@ -31,6 +31,6 @@ params <- list(
   spatial = list(mean = 0, sd = 0.75),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 50), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 50), spatial_region = spatial_region)
 temporal_conditional_intensity(hawkes, params, c(5, 5))
 }

--- a/man/time_scaled_residuals.Rd
+++ b/man/time_scaled_residuals.Rd
@@ -26,7 +26,7 @@ params <- list(
   spatial = list(mean = 0, sd = 0.1),
   temporal = list(rate = 2)
 )
-hawkes <- rHawkes(params, time_window = c(0, 100), spatial_region = spatial_region)
+hawkes <- rHawkes(params = params, time_window = c(0, 100), spatial_region = spatial_region)
 est <- hawkes_mle(hawkes, inits = params)
 residuals <- time_scaled_residuals(hawkes, est)
 
@@ -50,10 +50,10 @@ params <- list(
 )
 data("example_background_covariates")
 hawkes <- rHawkes(
-  params,
-  c(0, 50),
-  example_background_covariates,
-  covariate_columns = c("X1", "X2"),
+  params = params,
+  time_window = c(0, 50),
+  spatial_region = example_background_covariates,
+  background_process = ~ X1 + X2,
   spatial_burnin = 1
 )
 est <- hawkes_mle(hawkes, inits = params, boundary = 1)

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -124,7 +124,7 @@ hawkes <- rHawkes(
   params = true_params,
   time_window = c(0, 40),
   spatial_region = spatial_region,
-  covariate_columns = "center",
+  background_process = ~ center,
   spatial_burnin = 1
 )
 


### PR DESCRIPTION
## Summary
- update `rHawkes()` to accept an optional `hawkes` object as the leading argument, reuse stored metadata when present, and keep background covariates driven by formulas
- add an internal converter to rebuild background formulas from stored column metadata and apply it in bootstrap resampling helpers
- move `hawkes_mle()` back to a `hawkes`-first signature and refresh documentation and vignette examples to match the revised interfaces

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0484dcfac8329b0b7f8affdeda8c5