### PR TITLE
Infer background covariate columns from initial parameters

### DIFF
--- a/R/block_bootstrap.R
+++ b/R/block_bootstrap.R
@@ -32,7 +32,7 @@ extend_data_t_only <- function(hawkes, block_length_t) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -97,7 +97,7 @@ sample_blocks <- function(hawkes, num_blocks) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -187,7 +187,7 @@ block_bootstrap <- function(hawkes, est, B, num_blocks, alpha = .05, parallel = 
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, est$est)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/cluster_bootstrap.R
+++ b/R/cluster_bootstrap.R
@@ -38,7 +38,7 @@ sample_clusters <- function(hawkes, parent_mat, boundary = NULL) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -189,7 +189,7 @@ cluster_bootstrap <- function(hawkes, est, B, alpha = .05, parallel = FALSE, max
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, est$est)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/internals.R
+++ b/R/internals.R
@@ -40,6 +40,43 @@
 }
 
 
+#' (Internal) Resolve background covariate column names
+#'
+#' Determines the covariate columns to use when the Hawkes object does not have
+#' the `covariate_columns` attribute set. Falls back to the names of the
+#' background rate parameters (excluding any intercept term).
+#'
+#' @param attrs A list of attributes from a `hawkes` object.
+#' @param parameters Optional parameter list (e.g., inits or estimates) that
+#'   contains a `background_rate` element.
+#'
+#' @returns A character vector of covariate column names or `NULL` when no
+#'   covariates are present.
+#' @keywords internal
+.resolve_covariate_columns <- function(attrs, parameters = NULL) {
+  covariate_columns <- attrs$covariate_columns
+
+  if (is.null(covariate_columns) && !is.null(parameters)) {
+    background_rate <- parameters$background_rate
+
+    if (!is.null(background_rate)) {
+      background_names <- names(background_rate)
+
+      if (!is.null(background_names)) {
+        intercept_mask <- tolower(background_names) %in% c("intercept", "(intercept)")
+        covariate_columns <- background_names[!intercept_mask]
+
+        if (length(covariate_columns) == 0) {
+          covariate_columns <- NULL
+        }
+      }
+    }
+  }
+
+  covariate_columns
+}
+
+
 #' Flatten a nested parameter list into a numeric vector of free parameters with names
 #'
 #' @param params A nested list of parameter values, including a `$fixed` sublist.

--- a/R/likelihood_functions.R
+++ b/R/likelihood_functions.R
@@ -33,7 +33,7 @@ conditional_intensity <- function(hawkes, parameters) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, parameters)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -52,10 +52,10 @@ conditional_intensity <- function(hawkes, parameters) {
 
   background_rate <- as.numeric(background_rate)
 
-  if(!exists("covariate_columns", inherits = FALSE)){
-    X <- matrix(rep(1,nrow(hawkes)), ncol = 1)
+  if (is.null(covariate_columns)) {
+    X <- matrix(rep(1, nrow(hawkes)), ncol = 1)
   } else {
-    X <- cbind(1, hawkes[,covariate_columns, .drop = FALSE] |> sf::st_drop_geometry() |> as.matrix())
+    X <- cbind(1, hawkes[, covariate_columns, .drop = FALSE] |> sf::st_drop_geometry() |> as.matrix())
   }
 
 
@@ -146,7 +146,7 @@ spatial_conditional_intensity <- function(hawkes, parameters, time, stepsize) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, parameters)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -171,12 +171,17 @@ spatial_conditional_intensity <- function(hawkes, parameters, time, stepsize) {
   x <- sf::st_coordinates(point_grid)[,1]
   y <- sf::st_coordinates(point_grid)[,2]
 
-  X <- point_grid |>
-    sf::st_drop_geometry() |>
-    dplyr::select(tidyselect::all_of(covariate_columns))
+  covariate_values <- point_grid |>
+    sf::st_drop_geometry()
 
-  X <- cbind(1,X) |>
-    as.matrix()
+  if (is.null(covariate_columns)) {
+    X <- matrix(1, nrow = nrow(covariate_values), ncol = 1)
+  } else {
+    X <- covariate_values |>
+      dplyr::select(tidyselect::all_of(covariate_columns)) |>
+      as.matrix()
+    X <- cbind(1, X)
+  }
 
   background_rate <- parameters$background_rate
   triggering_rate <- parameters$triggering_rate
@@ -253,7 +258,7 @@ temporal_conditional_intensity <- function(hawkes, parameters, coordinates, step
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, parameters)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -359,7 +364,7 @@ log_likelihood <- function(hawkes, parameters) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, parameters)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/maximization_functions.R
+++ b/R/maximization_functions.R
@@ -29,7 +29,7 @@
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -67,7 +67,7 @@
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/maximum_likelihood_estimation.R
+++ b/R/maximum_likelihood_estimation.R
@@ -53,7 +53,7 @@ parent_est <- function(hawkes, parameters) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, parameters)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -159,7 +159,7 @@ est_params <- function(hawkes, parameters, parent_est_mat, boundary = NULL, fixe
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, parameters)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -330,7 +330,7 @@ hawkes_mle <- function(hawkes, inits, boundary = NULL, max_iters = 500, verbose 
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, inits)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/parametric_bootstrap.R
+++ b/R/parametric_bootstrap.R
@@ -59,7 +59,7 @@ parametric_bootstrap <- function(hawkes, est, B, alpha = 0.05, parallel = FALSE,
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, est$est)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/plot_hawkes.R
+++ b/R/plot_hawkes.R
@@ -40,7 +40,7 @@ plot_hawkes <- function(hawkes, color = "time", est = NULL,...) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler

--- a/R/residuals.R
+++ b/R/residuals.R
@@ -41,7 +41,6 @@ time_scaled_residuals <- function(hawkes, est) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -56,6 +55,8 @@ time_scaled_residuals <- function(hawkes, est) {
   if (class(est)[1] == "hawkes_fit") {
     est <- est$est
   }
+
+  covariate_columns <- .resolve_covariate_columns(attrs, est)
 
   background_rate <- est$background_rate
   triggering_rate <- est$triggering_rate

--- a/R/subsample.R
+++ b/R/subsample.R
@@ -30,7 +30,7 @@ sample_subregion <- function(hawkes, length) {
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler
@@ -96,7 +96,7 @@ subsample <- function(hawkes, est, B, length, alpha, parallel = FALSE, max_iters
   # Assign all attributes to variables in the function environment
   time_window <- attrs$time_window
   spatial_region <- attrs$spatial_region
-  covariate_columns    <- attrs$covariate_columns
+  covariate_columns <- .resolve_covariate_columns(attrs, est$est)
   spatial_family    <- attrs$spatial_family
   temporal_family    <- attrs$temporal_family
   spatial_sampler    <- attrs$spatial_sampler


### PR DESCRIPTION
## Summary
- add an internal helper that derives covariate column names from background-rate parameter names when the hawkes object lacks them
- update estimation, likelihood, residual, and bootstrap workflows to call the helper so background covariates are picked up automatically

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_690bbff93ab8832989f711bb86fce8be